### PR TITLE
Fixed overridden delegates were not forwarded

### DIFF
--- a/Sources/Transition/MotionTransition+Complete.swift
+++ b/Sources/Transition/MotionTransition+Complete.swift
@@ -48,8 +48,7 @@ extension MotionTransition {
       transitionContext = nil
       fromViewController = nil
       toViewController = nil
-      isNavigationController = false
-      isTabBarController = false
+      transitioningViewController = nil
       forceNonInteractive = false
       animatingToViews.removeAll()
       animatingFromViews.removeAll()

--- a/Sources/Transition/MotionTransition+UINavigationControllerDelegate.swift
+++ b/Sources/Transition/MotionTransition+UINavigationControllerDelegate.swift
@@ -38,7 +38,7 @@ extension MotionTransition: UINavigationControllerDelegate {
     isPresenting = .push == operation
     fromViewController = fromViewController ?? fromVC
     toViewController = toViewController ?? toVC
-    isNavigationController = true
+    transitioningViewController = navigationController
     
     return self
   }

--- a/Sources/Transition/MotionTransition+UITabBarControllerDelegate.swift
+++ b/Sources/Transition/MotionTransition+UITabBarControllerDelegate.swift
@@ -30,6 +30,11 @@ import UIKit
 
 extension MotionTransition: UITabBarControllerDelegate {
   public func tabBarController(_ tabBarController: UITabBarController, shouldSelect viewController: UIViewController) -> Bool {
+    
+    guard false != tabBarController.previousTabBarDelegate?.tabBarController?(tabBarController, shouldSelect: viewController) else {
+        return false
+    }
+    
     if isTransitioning {
       cancel(isAnimated: false)
     }
@@ -54,7 +59,7 @@ extension MotionTransition: UITabBarControllerDelegate {
     isPresenting = toVCIndex > fromVCIndex
     fromViewController = fromViewController ?? fromVC
     toViewController = toViewController ?? toVC
-    isTabBarController = true
+    transitioningViewController = tabBarController
     
     return self
   }


### PR DESCRIPTION
Fixed enabling Motion causes delegate methods to not be called as described in #27 

I used [forwardingTarget(for:)](https://developer.apple.com/documentation/objectivec/nsobject/1418855-forwardingtarget) method in order to avoid manually implementing delegates and forwarding them to `previousXDelegate`. This way has a couple of benefits. If sometime Apple adds new delegate methods our code will not need to be changed and will forward those delegate methods without hesitation.