### PR TITLE
Fixed issue-29, unbalanced calls to begin/end appearance transitions

### DIFF
--- a/Sources/Transition/MotionTransition+Complete.swift
+++ b/Sources/Transition/MotionTransition+Complete.swift
@@ -65,6 +65,7 @@ extension MotionTransition {
       progress = 0
       totalDuration = 0
       state = .possible
+      isModalTransition = false
     }
     
     state = .completing

--- a/Sources/Transition/MotionTransition+UIViewControllerTransitioningDelegate.swift
+++ b/Sources/Transition/MotionTransition+UIViewControllerTransitioningDelegate.swift
@@ -41,6 +41,7 @@ extension MotionTransition: UIViewControllerTransitioningDelegate {
     
     state = .notified
     isPresenting = true
+    isModalTransition = true
     fromViewController = fromViewController ?? presenting
     toViewController = toViewController ?? presented
     
@@ -54,6 +55,7 @@ extension MotionTransition: UIViewControllerTransitioningDelegate {
     
     state = .notified
     isPresenting = false
+    isModalTransition = true
     fromViewController = fromViewController ?? dismissed
     return self
   }

--- a/Sources/Transition/MotionTransition.swift
+++ b/Sources/Transition/MotionTransition.swift
@@ -271,6 +271,13 @@ open class MotionTransition: NSObject {
   
   /// Whether or not we are presenting the destination view controller.
   public internal(set) var isPresenting = true
+    
+  /**
+   A boolean indicating if the transition is of modal type.
+   True if `viewController.present(_:animated:completion:)` or
+   `viewController.dismiss(animated:completion:)` is called, false otherwise.
+   */
+  public internal(set) var isModalTransition = false
   
   /// A boolean indicating whether the transition interactive or not.
   public var isInteractive: Bool {
@@ -588,8 +595,10 @@ internal extension MotionTransition {
       return
     }
     
-    fvc.beginAppearanceTransition(false, animated: true)
-    tvc.beginAppearanceTransition(true, animated: true)
+    if !isModalTransition {
+        fvc.beginAppearanceTransition(false, animated: true)
+        tvc.beginAppearanceTransition(true, animated: true)
+    }
     
     processForMotionDelegate(viewController: fvc) { [weak self] in
       guard let `self` = self else {
@@ -625,8 +634,10 @@ internal extension MotionTransition {
       return
     }
     
-    tvc.endAppearanceTransition()
-    fvc.endAppearanceTransition()
+    if !isModalTransition {
+        tvc.endAppearanceTransition()
+        fvc.endAppearanceTransition()
+    }
     
     processForMotionDelegate(viewController: fvc) { [weak self] in
       guard let `self` = self else {


### PR DESCRIPTION
Fixed issue #29. Calling `{begin,end}AppearanceTransition` methods for modal transitions was causing the issue since `UIKit` was already calling them internally.

I did rigorous testing after fixing the issue with multiple setups (TabsContoller, NavigationDrawer, NavigationContoller, BottomNavigationBar) to try various transitions types, it never showed up again. I examined the `view{Will,Did}{Appear,Disappear}` call trace and it was exactly same for `Motion` and `UIKit` modal transitions. Example trace:
```
viewWillDisappear AppRootController
viewWillDisappear NavigationController
viewWillDisappear BottomNavigationController
viewWillAppear ModalViewController
viewDidAppear ModalViewController
viewDidDisappear AppRootController
viewDidDisappear NavigationController
viewDidDisappear BottomNavigationController
viewWillDisappear ModalViewController
viewWillAppear AppRootController
viewWillAppear NavigationController
viewWillAppear BottomNavigationController
viewDidAppear AppRootController
viewDidAppear NavigationController
viewDidAppear BottomNavigationController
viewDidDisappear ModalViewController
```