### PR TITLE
Fixed issue-44, view is hidden below status bar during call

### DIFF
--- a/Motion.podspec
+++ b/Motion.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name = 'Motion'
   s.version = '1.5.0'
-  s.swift_version = '4.0'
+  s.swift_version = '4.2'
   s.license = 'MIT'
   s.summary = 'A library used to create beautiful animations and transitions for Apple devices.'
   s.homepage = 'http://cosmicmind.com'

--- a/Sources/Transition/MotionTransition+Complete.swift
+++ b/Sources/Transition/MotionTransition+Complete.swift
@@ -143,5 +143,33 @@ extension MotionTransition {
     }
     
     tContext?.completeTransition(isFinishing)
+    
+    let isModalDismissal = isModalTransition && !isPresenting
+    if isModalDismissal {
+      UIApplication.shared.fixRootViewY()
+    }
+  }
+}
+
+
+private extension UIApplication {
+  /**
+   When in-call, hotspot, or recording status bar is enabled, just after (custom) modal
+   dismissal transition animation ends `UITransitionView` is removed from the hierarchy
+   and that removal was moving `rootViewController.view` 20 points upwards. This function
+   should be called after transitioningContext.completeTransition(_:) upon modal dismissal
+   transition. It applies the work that `UITransitionView` should ideally have done after
+   custom modal dismissal. `UIKit` modal dismissals do not suffer from this.
+   
+   Fixes issue-44. See issue-44 for more info.
+   */
+  func fixRootViewY() {
+    guard statusBarFrame.height == 40, let window = keyWindow, let vc = window.rootViewController else {
+      return
+    }
+    
+    if vc.view.frame.maxY + 20 == window.frame.height {
+      vc.view.frame.origin.y += 20
+    }
   }
 }


### PR DESCRIPTION
Fixed issue #44.  When in-call, hotspot, or recording status bar is enabled, just after (custom) modal dismissal transition animation ends `UITransitionView` is removed from the hierarchy and that removal was moving `rootViewController.view` 20 points upwards, pushing `view` beneath statusbar and leaving a black gap at the bottom. The PR fixes this by pushing it 20px downwards, the work that `UITransitionView` should ideally have done after custom modal dismissal.

Also fixed issue #43