### PR TITLE
Update MotionAnimatorViewContext to inherit from NSObject

### DIFF
--- a/Sources/Animator/MotionAnimatorViewContext.swift
+++ b/Sources/Animator/MotionAnimatorViewContext.swift
@@ -28,7 +28,7 @@
 
 import UIKit
 
-internal class MotionAnimatorViewContext {
+internal class MotionAnimatorViewContext: NSObject {
   /// An optional reference to a MotionAnimator.
   var animator: MotionAnimator?
   


### PR DESCRIPTION
On occasion, I was getting a `exc_bad_access` crash stemming from `Motion.MotionCoreAnimationViewContext`.

After debugging through things, got the following error to show in the console:

```
2019-01-25 10:28:58.028317-0600 Humanity[26643:69763009] *** NSForwarding: warning: object 0x7b580004ec00 of class 'Motion.MotionCoreAnimationViewContext' does not implement methodSignatureForSelector: -- trouble ahead
Unrecognized selector -[Motion.MotionCoreAnimationViewContext observeValueForKeyPath:ofObject:change:context:]
2019-01-25 10:28:58.028587-0600 Humanity[26643:69763009] Unrecognized selector -[Motion.MotionCoreAnimationViewContext observeValueForKeyPath:ofObject:change:context:]
```
Researching shows this is a swift bug but a workaround is to inherit the class from `NSObject`

https://bugs.swift.org/browse/SR-7882?page=com.atlassian.jira.plugin.system.issuetabpanels%3Achangehistory-tabpanel

I have not been able to duplicate the crash since I made this change locally. 
