### PR TITLE
Add basic SwifPM manifest file

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "Motion",
+    // platforms: [.iOS("8.0")],
+    products: [
+        .library(name: "Motion", targets: ["Motion"])
+    ],
+    targets: [
+        .target(
+            name: "Motion",
+            path: "Sources"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ In the above code example, a box view is created with a width of 100, height of 
 > **Embedded frameworks require a minimum deployment target of iOS 8.**
 > - [Download Motion](https://github.com/CosmicMind/Motion/archive/master.zip)
 
-Read [Material - It's time to download](https://www.cosmicmind.com/danieldahan/lesson/6) to learn how to install Material using [GitHub](http://github.com), [CocoaPods](http://cocoapods.org), and [Carthage](https://github.com/Carthage/Carthage).
+Read [Material - It's time to download](https://www.cosmicmind.com/danieldahan/lesson/6) to learn how to install Material using [GitHub](http://github.com), [CocoaPods](http://cocoapods.org), [Carthage](https://github.com/Carthage/Carthage) and [Accio](https://github.com/JamitLabs/Accio).
 
 ## Change Log
 


### PR DESCRIPTION
This adds support for SwiftPM manifest based dependency managers. Specifically this adds support for installing via [Accio](https://github.com/JamitLabs/Accio) but will probably also work with SwiftPM once it's integrated into Xcode.