### PR TITLE
Add missing module

### DIFF
--- a/Sources/Extensions/Motion+Obj-C.swift
+++ b/Sources/Extensions/Motion+Obj-C.swift
@@ -23,6 +23,8 @@
  * THE SOFTWARE.
  */
 
+import ObjectiveC
+
 public struct AssociatedObject {
   /**
    Gets the Obj-C reference for the instance object within the UIView extension.

--- a/Sources/MotionViewOrderStrategy.swift
+++ b/Sources/MotionViewOrderStrategy.swift
@@ -23,6 +23,8 @@
  * THE SOFTWARE.
  */
 
+import Foundation
+
 @objc(MotionViewOrderStrategy)
 public enum MotionViewOrderStrategy: Int {
   case auto


### PR DESCRIPTION
Add missing module ( ObjectiveC, Foundation )
Fixed Build Error when using SPM (Swift Package Manager)