### PR TITLE
- Fixes warning when linked agains app extension for Carthage

### DIFF
--- a/Motion.xcodeproj/project.pbxproj
+++ b/Motion.xcodeproj/project.pbxproj
@@ -530,6 +530,7 @@
 		96C98DDA1E424AB000B22906 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -554,6 +555,7 @@
 		96C98DDB1E424AB000B22906 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
Hi, this one fixes a warning when linking the Carthage framework to an app extension target.
Relates to https://github.com/CosmicMind/Material/pull/1291